### PR TITLE
Add basic load balancing to proposals

### DIFF
--- a/services/proposals/templates/deployment.yaml
+++ b/services/proposals/templates/deployment.yaml
@@ -23,13 +23,15 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ['python3', 'propose.py']
-          lifecycle:
-              postStart:
-                  exec:
-                      command: ["/bin/sh", "-c", "export POD_ID=${HOSTNAME##*-}"]
+          # Hacky but whatever
+          # This issue needs to be resolved: https://github.com/kubernetes/kubernetes/issues/30427
+          command: ["python3", "propose.py"]
           env:
               - name: DBCONNECT
                 value: "mongodb://{{ .Values.mongouser }}:{{ .Values.mongopwd }}@{{ .Values.mongourl }}:{{ .Values.mongoport }}"
               - name: REPLICA_COUNT
-                value: {{ .Values.replicaCount }}
+                value: "{{ .Values.replicaCount }}"
+              - name: POD_NAME
+                valueFrom:
+                    fieldRef:
+                        fieldPath: metadata.name

--- a/services/proposals/templates/deployment.yaml
+++ b/services/proposals/templates/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata :
   name: {{ include "proposals.fullname" . }}
   labels:
@@ -8,7 +8,7 @@ metadata :
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
       matchLabels:
         app.kubernetes.io/name: {{ include "proposals.name" . }}
@@ -24,6 +24,12 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ['python3', 'propose.py']
+          lifecycle:
+              postStart:
+                  exec:
+                      command: ["/bin/sh", "-c", "export POD_ID=${HOSTNAME##*-}"]
           env:
               - name: DBCONNECT
                 value: "mongodb://{{ .Values.mongouser }}:{{ .Values.mongopwd }}@{{ .Values.mongourl }}:{{ .Values.mongoport }}"
+              - name: REPLICA_COUNT
+                value: {{ .Values.replicaCount }}

--- a/services/proposals/values.yaml
+++ b/services/proposals/values.yaml
@@ -7,6 +7,8 @@ image:
   tag: test
   pullPolicy: Always
 
+replicaCount: 2
+
 mongouser: root
 mongopwd: password
 mongourl: cosmos-mongodb.default.svc.cluster.local


### PR DESCRIPTION
Can now spawn any amount of replicas, and ingested pdfs will be distributed among machines based off the id hash on the ingested mongo object.