### PR TITLE
Clear sqlite on successive inference runs to prevent memory leak.

### DIFF
--- a/services/detection/src/infer.py
+++ b/services/detection/src/infer.py
@@ -6,8 +6,20 @@ from torch_model.inference.data_layer.inference_loader import InferenceLoader
 from ingest_images import ImageDB
 
 
+def get_model(model_config, weights, device_str):
+    cfg = ConfigManager(model_config)
+    model = MMFasterRCNN(cfg)
+    model.load_state_dict(torch.load(weights, map_location={"cuda:0": device_str}))
+    model.eval()
+    def bn_train(m):
+        if type(m) == torch.nn.BatchNorm2d:
+            m.train()
+    model.apply(bn_train)
+    device = torch.device(device_str)
+    model.to(device)
+    return model
 
-def run_inference(page_objs, model_config, weights, device_str):
+def run_inference(model, page_objs, model_config, device_str):
     """
     Main function to run inference. Writes a bunch of XMLs to out_dir
     :param page_objs: List of page objects
@@ -18,20 +30,14 @@ def run_inference(page_objs, model_config, weights, device_str):
     :param device_str: Device config
     """
     cfg = ConfigManager(model_config)
-    model = MMFasterRCNN(cfg)
-    model.load_state_dict(torch.load(weights, map_location={"cuda:0": device_str}))
-    model.eval()
-    def bn_train(m):
-        if type(m) == torch.nn.BatchNorm2d:
-            m.train()
-    model.apply(bn_train)
-    session, ingest_objs = ImageDB.initialize_and_ingest(page_objs,
+    ingest_objs = ImageDB.initialize_and_ingest(page_objs,
                                                          cfg.WARPED_SIZE,
                                                          'test',
                                                          cfg.EXPANSION_DELTA)
-    loader = InferenceLoader(session, ingest_objs, cfg.CLASSES)
+    loader = InferenceLoader(ingest_objs, cfg.CLASSES)
     device = torch.device(device_str)
-    model.to(device)
     infer_session = InferenceHelper(model, loader, device)
-    return infer_session.run()
+    results = infer_session.run()
+    ImageDB.cleanup()
+    return results
 

--- a/services/detection/src/torch_model/inference/data_layer/inference_loader.py
+++ b/services/detection/src/torch_model/inference/data_layer/inference_loader.py
@@ -21,14 +21,14 @@ class InferenceLoader(XMLLoader):
     Inference dataset object, based on XMLLoader
     """
 
-    def __init__(self, session, ingest_objs, classes):
+    def __init__(self, ingest_objs, classes):
         """
         Init function
         :param session: DB Session
         :param ingest_objs: Database statistics object
         :param classes: List of classes
         """
-        super().__init__(session, ingest_objs, classes)
+        super().__init__(ingest_objs, classes)
 
     @staticmethod
     def collate(batch):

--- a/services/detection/src/torch_model/train/data_layer/xml_loader.py
+++ b/services/detection/src/torch_model/train/data_layer/xml_loader.py
@@ -22,8 +22,6 @@ from uuid import uuid4
 from tqdm import tqdm
 from torch_model.utils.bbox import BBoxes
 from ingest_images import db_ingest, get_example_for_uuid, compute_neighborhoods, ImageDB
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy import create_engine
 from dataclasses import dataclass
 
 normalizer = NormalizeWrapper()
@@ -82,14 +80,14 @@ class XMLLoader(Dataset):
     other than annotations
     """
 
-    def __init__(self, session, ingest_objs, classes):
+    def __init__(self, ingest_objs, classes):
         """
         Initialize a XML loader object
         :param xml_dir: directory to get XML from
         :param img_dir: directory to load PNGs from
         :param img_type: the image format to load in
         """
-        self.session = session
+        self.session = ImageDB.build()
         self.uuids = ingest_objs.uuids
         self.ngt_boxes = ingest_objs.ngt_boxes
         self.nproposals = ingest_objs.nproposals
@@ -99,6 +97,9 @@ class XMLLoader(Dataset):
         self.print_stats()
         print(f"# of gt boxes:{self.ngt_boxes}")
         print(f"# of proposals:{self.nproposals}")
+
+    def __del__(self):
+        self.session.close()
 
 
     def __len__(self):

--- a/services/ocr/docker-compose.yml
+++ b/services/ocr/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     ocr:
         build: .
         ipc: host
-        #command: "python3 ocr.py 10 --no-skip"
-        volumes:
-            - .:/develop/
-        command: "tail -F /dev/null"
+        command: "python3 ocr.py 10 --no-skip"
+        #volumes:
+        #    - .:/develop/
+        #command: "tail -F /dev/null"
         environment:
             - DBCONNECT


### PR DESCRIPTION
Refactor SQLLite fns: spawn sessions on per commit basis instead of sharing single session, perform cleanup after a batch of inference

Train scripts will need to be updated accordingly.