### PR TITLE
Fix model path + resolve small dependency issue

### DIFF
--- a/services/detection/Dockerfile
+++ b/services/detection/Dockerfile
@@ -71,7 +71,7 @@ RUN pip install numpy==1.15.4 \
         opencv-python \
         pascal-voc-writer \
         imgaug \
-        Pillow \
+        Pillow==6.1 \
         redis \
         sqlalchemy
 

--- a/services/detection/src/model_weights.pth
+++ b/services/detection/src/model_weights.pth
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c6d184255fa5a47ee249b7591b98607ea7f18537a2d110691670f668e30a43a4
-size 1724397978


### PR DESCRIPTION
The more recent model file was getting overwritten by what I assume is an older one because of the structure of the Dockerfile.

The newer weight is copied into the image build here:
https://github.com/UW-COSMOS/Cosmos/blob/master/services/detection/Dockerfile#L80

But an older version, living in `detection/src/` got copied to the same path within the image the next line. This resulted in a wave of crappy results (obvious figures/tables getting flagged as body text especially).

When testing, there was an issue that popped up within the pillow dependency, as noted in the commit message.