### PR TITLE
Retrieval API updates

### DIFF
--- a/cosmos/api/cosmos/retrieval.py
+++ b/cosmos/api/cosmos/retrieval.py
@@ -42,7 +42,7 @@ else:
 # NOTE: docid/doi parameters undocumented intentionally for obscurity IAR - 28.Jan.2021
 parameter_defs = {
         'api_key': '(str, Required) - String token that grants access to the COSMOS extractions.',
-        'query': '(str, Required) - term or comma-separated list of terms to search for. Default search logic will utilize an OR of comma- or space-separated words.',
+        'query': '(str, Required) - term or comma-separated list of terms to search for. Default search logic will utilize an OR of comma-separated words.',
         'type': '[Table, Figure, Equation, Body Text, Combined] - the type of object to search for.',
         'page': '(int) - Page of results (starts at 0)',
         'id' : 'Internal COSMOS ID of an object to retrieve.',

--- a/cosmos/api/cosmos/retrieval.py
+++ b/cosmos/api/cosmos/retrieval.py
@@ -77,7 +77,8 @@ fields_defs = {
 def require_apikey(fcn):
     @wraps(fcn)
     def decorated_function(*args, **kwargs):
-        if request.args.get('api_key') and request.args.get('api_key') in API_KEYS:
+#        if request.args.get('api_key') and request.args.get('api_key') in API_KEYS:
+        if True:
             return fcn(*args, **kwargs)
         elif len(request.args) == 0: # if bare request, show the helptext even without an API key
             return fcn(*args, **kwargs)
@@ -342,7 +343,7 @@ def object(objid):
 @bp.route(f'/statistics', endpoint='statistics', methods=['GET'])
 @require_apikey
 def statistics():
-    return jsonify({'n_pages': current_app.retriever.count("page"), 'n_objects': current_app.retriever.count("object"), 'n_pdfs': current_app.retriever.count("fulldocument")})
+    return jsonify({'n_pages': current_app.retriever.count("page", dataset_id=DATASET_ID), 'n_objects': current_app.retriever.count("object", dataset_id=DATASET_ID), 'n_pdfs': current_app.retriever.count("fulldocument", dataset_id=DATASET_ID)})
 
 
 @bp.route('/entity', endpoint='entity', methods=['GET'])

--- a/cosmos/api/cosmos/retrieval.py
+++ b/cosmos/api/cosmos/retrieval.py
@@ -34,6 +34,11 @@ if "N_RESULTS" in os.environ:
 else:
     N_RESULTS=30
 
+if "DATASET_ID" in os.environ:
+    DATASET_ID=os.environ['DATASET_ID']
+else:
+    DATASET_ID=None
+
 if "IMG_TYPE" in os.environ:
     IMG_TYPE=os.environ['IMG_TYPE']
 else:
@@ -206,8 +211,8 @@ def document():
         if docid == '':
             return jsonify({'error' : 'DOI not in xDD system!', 'v' : VERSION})
 
-    count = current_app.retriever.search(None, get_count=True, final=False, docids=[docid])
-    results = current_app.retriever.search(None, docids=[docid], final=True)
+    count = current_app.retriever.search(None, get_count=True, final=False, docids=[docid], dataset_id=DATASET_ID)
+    results = current_app.retriever.search(None, docids=[docid], final=True, dataset_id=DATASET_ID)
     if len(results) == 0:
         return {'page': 0, 'objects': [], 'v': VERSION, 'license': LICENSE}
     bibjsons = get_bibjsons([i['pdf_name'].replace(".pdf", "")  for i in results])
@@ -265,14 +270,14 @@ def search():
 
     # TODO: parameter toggle for entity searching
 
-    count = current_app.retriever.search(query, entity_search=False, ndocs=N_RESULTS, page=page_num, cls=obj_type,
+    count = current_app.retriever.search(query, entity_search=False, ndocs=N_RESULTS, page=page_num, cls=obj_type, dataset_id=DATASET_ID,
                                                detect_min=base_confidence, postprocess_min=postprocessing_confidence,
                                                get_count=True, final=False, inclusive=inclusive, document_filter_terms=document_filter_terms, docids=docids, obj_id=obj_id)
     if 'count' in request.endpoint:
         return jsonify({'total_results': count, 'v': VERSION, 'license': LICENSE})
     current_app.logger.info(f"page: {page_num}, cls: {obj_type}, detect_min: {base_confidence}, postprocess_min: {postprocessing_confidence}")
     current_app.logger.info(f"Passing in {document_filter_terms}")
-    results = current_app.retriever.search(query, entity_search=False, ndocs=N_RESULTS, page=page_num, cls=obj_type,
+    results = current_app.retriever.search(query, entity_search=False, ndocs=N_RESULTS, page=page_num, cls=obj_type, dataset_id=DATASET_ID,
                                          detect_min=base_confidence, postprocess_min=postprocessing_confidence, get_count=False, final=True, inclusive=inclusive, document_filter_terms=document_filter_terms, docids=docids, obj_id=obj_id)
     if len(results) == 0:
         return {'page': 0, 'objects': [], 'v': VERSION, 'license' : LICENSE}

--- a/cosmos/api/cosmos/retrieval.py
+++ b/cosmos/api/cosmos/retrieval.py
@@ -173,13 +173,24 @@ def document():
 
     # TODO: go doi->xddid
     # TODO: pass docid into current_app.retriever.search ?
-    count = current_app.retriever.search(None, get_count=True, docids=[docid])
-    results = current_app.retriever.search(None, docids=[docid])
+    count = current_app.retriever.search(None, get_count=True, final=False, docids=[docid])
+    results = current_app.retriever.search(None, docids=[docid], final=True)
     # TODO: filter response to just be contents, ...
     if len(results) == 0:
         return {'page': 0, 'objects': [], 'v': VERSION}
     bibjsons = get_bibjsons([i['pdf_name'].replace(".pdf", "")  for i in results])
-    return jsonify({'v' : VERSION, 'total': count, 'page': 0, 'objects': results})
+
+    results = [
+            {"id" : i["children"][0]["id"],
+                "cls" : i["children"][0]["cls"],
+                "postprocessing_confidence": i["children"][0]["postprocessing_confidence"],
+                "base_confidence" : i["children"][0]["base_confidence"],
+                "content" : i["children"][0]["content"],
+                "header_content" : i["children"][0]["header_content"]
+                } for i in results
+            ]
+
+    return jsonify({'v' : VERSION, 'total': count, 'page': 0, 'bibjson' : bibjsons[docid], 'objects': results})
 
 
 @bp.route(f'/count', endpoint='count')

--- a/cosmos/api/cosmos/retrieval.py
+++ b/cosmos/api/cosmos/retrieval.py
@@ -159,6 +159,29 @@ def tags():
     resp = {"v":1,"license":"MIT","data":[{"tag_id":1,"name":"Body Text","description":"The primary text of an article","color":"#aaaaaa","created":"2019-04-02T20:04:30.849Z"},{"tag_id":2,"name":"Figure","description":"A chart, graph, or other graphical display","color":"#a15231","created":"2019-04-02T20:04:30.849Z"},{"tag_id":3,"name":"Figure Note","description":"A footnote explanation of specific content in a figure","color":"#801515","created":"2019-04-02T20:04:30.849Z"},{"tag_id":4,"name":"Figure Caption","description":"A text description associated with an entire figure","color":"#c45778","created":"2019-04-02T20:04:30.849Z"},{"tag_id":5,"name":"Table","description":"A tabular representation of information","color":"#432F75","created":"2019-04-02T20:04:30.849Z"},{"tag_id":6,"name":"Table Note","description":"A footnote to explain a subset of table content","color":"#162c57","created":"2019-04-02T20:04:30.849Z"},{"tag_id":7,"name":"Table Caption","description":"A text description associated with an entire table","color":"#73548f","created":"2019-04-02T20:04:30.849Z"},{"tag_id":8,"name":"Page Header","description":"Document-wide summary information, including page no., at top of page","color":"#2a7534","created":"2019-04-02T20:04:30.849Z"},{"tag_id":9,"name":"Page Footer","description":"Document-wide summary information, including page no., at bottom of page","color":"#345455","created":"2019-04-02T20:04:30.849Z"},{"tag_id":10,"name":"Section Header","description":"Text identifying section within text of document","color":"#1aa778","created":"2019-04-02T20:04:30.849Z"},{"tag_id":11,"name":"Equation","description":"An equation","color":"#2C4770","created":"2019-04-02T20:04:30.849Z"},{"tag_id":12,"name":"Equation label","description":"An identifier for an equation","color":"#4D658D","created":"2019-04-02T20:04:30.849Z"},{"tag_id":13,"name":"Abstract","description":"Abstract of paper","color":"#D4A26A","created":"2019-04-02T20:04:30.849Z"},{"tag_id":14,"name":"Reference text","description":"References to other works","color":"#804D15","created":"2019-04-02T20:04:30.849Z"},{"tag_id":15,"name":"Other","description":"Textual metadata and image content that is not semantically meaningful","color":"#96990c","created":"2019-04-02T20:04:30.849Z"},{"tag_id":16,"name":"Equation definition","description":"An equation definition","color":"#23477e","created":"2019-04-02T20:04:30.849Z"},{"tag_id":17,"name":"Symbol","description":"A symbol","color":"#4c2c70","created":"2019-04-02T20:04:30.849Z"},{"tag_id":18,"name":"Symbol definition","description":"A symbol definition","color":"#ff0000","created":"2019-04-02T20:04:30.849Z"}]}
     return jsonify(resp)
 
+
+@bp.route(f'/document', endpoint='document')
+def document():
+    """
+    Bring back document-level summary.
+    TODO: bring back bibjson
+    TODO: summarize objects (with objectids) for the document
+    TODO: better document filtering here?
+    """
+
+    docid = request.args.get('docid', default='', type=str)
+
+    # TODO: go doi->xddid
+    # TODO: pass docid into current_app.retriever.search ?
+    count = current_app.retriever.search(None, get_count=True, docids=[docid])
+    results = current_app.retriever.search(None, docids=[docid])
+    # TODO: filter response to just be contents, ...
+    if len(results) == 0:
+        return {'page': 0, 'objects': [], 'v': VERSION}
+    bibjsons = get_bibjsons([i['pdf_name'].replace(".pdf", "")  for i in results])
+    return jsonify({'v' : VERSION, 'total': count, 'page': 0, 'objects': results})
+
+
 @bp.route(f'/count', endpoint='count')
 @bp.route(f'/search', endpoint='search')
 def search():

--- a/cosmos/retrieval/retrieval/elastic_retriever.py
+++ b/cosmos/retrieval/retrieval/elastic_retriever.py
@@ -544,7 +544,7 @@ class ElasticRetriever(Retriever):
             logger.info('Done building equations index')
         logger.info('Done building object index')
 
-    def count(self, index):
+    def count(self, index, dataset_id=None):
         if self.awsauth is not None:
             connections.create_connection(hosts=self.hosts,
                                           http_auth=self.awsauth,
@@ -555,6 +555,9 @@ class ElasticRetriever(Retriever):
         else:
             connections.create_connection(hosts=self.hosts)
         s = Search(index=index)
+        if dataset_id is not None:
+            s = s.filter('term', dataset_id__raw=dataset_id)
+
         return s.count()
 
     def delete(self, dataset_id):

--- a/cosmos/retrieval/retrieval/elastic_retriever.py
+++ b/cosmos/retrieval/retrieval/elastic_retriever.py
@@ -537,7 +537,7 @@ class ElasticRetriever(Retriever):
                            pdf_name=row['pdf_name'],
                            img_pth=row['img_pth'],
                            ))
-                    if len(to_add) == 1000:
+                    if len(to_add) == 500:
                         bulk(connections.get_connection(), (upsert(d) for d in to_add))
                         to_add = []
                 bulk(connections.get_connection(), (upsert(d) for d in to_add))

--- a/cosmos/retrieval/retrieval/elastic_retriever.py
+++ b/cosmos/retrieval/retrieval/elastic_retriever.py
@@ -188,7 +188,7 @@ class ElasticRetriever(Retriever):
         self.hosts = hosts
         self.awsauth = awsauth
 
-    def search(self, query, entity_search=False, ndocs=30, page=0, cls=None, detect_min=None, postprocess_min=None, get_count=False, final=False, inclusive=False, document_filter_terms=[], docids=[], obj_id=None):
+    def search(self, query, entity_search=False, ndocs=30, page=0, cls=None, detect_min=None, postprocess_min=None, get_count=False, final=False, inclusive=False, document_filter_terms=[], docids=[], obj_id=None, dataset_id=None):
         if self.awsauth is not None:
             connections.create_connection(hosts=self.hosts,
                                           http_auth=self.awsauth,
@@ -257,6 +257,9 @@ class ElasticRetriever(Retriever):
             s = Search(index='eo-site')
             if cls is not None:
                 s = s.filter('term', cls__raw=cls)
+
+            if dataset_id is not None:
+                s = s.filter('term', dataset_id__raw=dataset_id)
 
             # Filter figures/tables, enforcing size not approaching full-page. TODO: Overkill and will cut legitimate full-page tables
             q = q & Q('bool', must_not=[Q('bool', must=[Q('match_phrase', cls__raw='Figure'), Q('range', area={'gte': 2000000})])])


### PR DESCRIPTION
- API key requirement added (though currently disabled)
- Document level lookups and filters
- Filter by dataset_id
- Store and filter on object size
- Concatenate `contents` and `header_content` field into one `full_contents` field and use that for retrieval