### PR TITLE
Improvements to the HTCondor cosmos script including

### DIFF
--- a/htcosmos/README.txt
+++ b/htcosmos/README.txt
@@ -1,9 +1,9 @@
 --- submitting a uwcosmos document set as a HTCondor job ---
 
 Files in this directory demonstrate how to submit a collection of PDF files to
-HTCondor to be processed using the cosmos model producing PARQUET files and images.
+HTCondor to be processed using the COSMOS model producing PARQUET files and images.
 
-There are two example submit files.
+There are four example submit files, but the typical workflow will use only two of them. The files are
 
 	parquet.sub
 		process a directory PDF files from ./input or directory supplied on submit command line.
@@ -17,6 +17,8 @@ There are two example submit files.
 
 			from=<full-path-to-input-directory>  # default is ./input
 			propose=true                         # defaults to undefined/false
+			infer=true                           # defaults to undefined/false, ignored if propose=true
+			post=true                            # defaults to undefined/false, ignored if propose=true or infer=true
 			disk=<request_disk-amount>           # defaults to 500MB
 			memory=<request_memory-amount>       # defaults to 6GB
 			cpus=<request_cpus-amount>           # defaults to 1
@@ -25,10 +27,10 @@ There are two example submit files.
 
 			condor_submit from=/path/to/input parquet.sub
 
-		You can also split the processing up into two phases, a CPU only propose phase
-		and a GPU processing and post-processing phase.  To do that, either use propose.sub
-		or supply the propose=true option when you submit parquet.sub.
-		When you pass propose=true, then the PDF files are just pre-processed, with PNG and pickle files
+		You can also split the processing up into two or three phases. Two phase is a CPU only propose phase
+		and a GPU processing and post-processing phase. This is the recommended workflow.  For this workflow,
+		either use propose.sub or pass propose=true on the command line when you submit parquet.sub.
+		When you pass propose=true or use propose.sub, the PDF files are just pre-processed, with PNG and pickle files
 		being returned in the ./pages directory.  A job of this sort will be run without a GPU.  Once a
 		propose=true job has finised,  you can submit parquet.sub again with the same inputs and it will
 		transfer the PNG and pickle files to a machine with a GPU and finish the processing, placing
@@ -39,18 +41,28 @@ There are two example submit files.
 		do not need to be created before using this submit file.  This is the preferred way to do the
 		page printing, pdf parsing and proposals.
 
+	infer.sub
+		The equivalent of 'condor_submit infer=true parquet.sub'. Use this as the second (GPU inference model)
+		phase of a 3 phase workflow.  Note that the 2 phase workflow is probably better...
+
+	post.sub
+		The equivalent of 'condor_submit post=true parquet.sub'. Use this as the third (aggregation) phase of a
+		3 phase workflow.  Note that the 2 phase workflow is probably better...
+
 	make_parquet.py
 		A script intended to be run as part of a HTCondor job inside a uwcosmos/cosmos-ingestion docker container.
-		It can process a pdf and make parquet files, or it can stop after the propose step. When the inputs
-		include the pages and proposals, it will use those and go right to the GPU inference processing step.
-		The above submit files use this script.  Some intermediate data can be returned in json format
+		It can process a pdf and make parquet files, or it can stop after the propose step or after the infer step.
+		When the inputs include the pages and proposals, it will use those and go right to the GPU inference processing step.
+		When the inputs include 'detected_objs'.  it will skip GPU inferencing and just do the post-processing steps.
+
+		The above submit files use this script.  Some intermediate data can optionally be returned in json format
 		since this is more human-readable. stdout and stderr are used for progress logs. The stdout log
 		lines have timestamps.
 
 		Usage: python make_parquet.py <pdf-dir> <page_info_dir> <output_dir>
 			where:
 				<pdf-dir>       is the input directory, it should contain the PDF files to process
-				<page_info_dir> is the pages directory, page PNGs and pickles are read and written here
+				<page_info_dir> is the pages directory, page PNGs and pickles and progress files are read and written here
 				<output_dir>    is the output directory, parquet files are written here
 
 			This script reads options from the environment
@@ -60,7 +72,42 @@ There are two example submit files.
 				AGGREGATIONS=<list of aggregations>
 				KEEP_INFO=[pickle,page,pad,json] # intermediate files not in this list will not be returned
 				JUST_PROPOSE=[True] # when present, only the page printing, pdf parse and propose steps are done
+				SKIP_AGGREGATION=[True] # when present, only do GPU inference model step
+				JUST_AGGREGATION=[True]	# when present, only do the post-processing aggregation and parquet creation step
 
+			Only one of the JUST_PROPOSE, SKIP_AGREGATION, and JUST_AGGREGATION options can be used for a single job.
+
+	times
+		A quick and dirty shell script to scan the stdout of make_parquet.py (i.e. the <clusterid>.out of the HTCondor job)
+		and sum up the times represented by similar lines. Uses the processing_time.pl perl script
+
+	processing_time.pl
+		A helper perl script used by the times shell script
+
+If the size if the input PDF files is more than 25MB,  you should increase the requested disk for the HTCondor jobs
+by adding disk=<value> to the submit command line. Disk usage is typically 30x the size of the inputs for intermediate files.
+The final parquet files and images are roughly the same size as the input PDF files.
+
+The recommended workflow is to create a directory of PDF files to process (/path/to/input)
+then run the two job workflow.
+
+	condor_submit from=/path/to/input propose.sub && condor_wait -echo propose.log
+	condor_submit from=/path/to/input parquet.sub && condor_wait -echo parquet.log
+
+There is an alternative workflow using a single job.  This workflow does all of the work
+on a machine with a GPU, it is overall faster, but is wasteful of GPU resources.
+
+	mkdir pages
+	mkdir output
+	condor_submit from=/path/to/input parquet.sub && condor_wait -echo parquet.log
+
+There is another alternative workflow using three jobs, this workflow uses a GPU only
+for the second job, the first and last are CPU only.  This is the slowest workflow
+but makes the most efficient use of GPU resources.
+
+	condor_submit from=/path/to/input propose.sub && condor_wait -echo propose.log
+	condor_submit from=/path/to/input infer.sub && condor_wait -echo infer.log
+	condor_submit from=/path/to/input post.sub && condor_wait -echo post.log
 
 
 

--- a/htcosmos/infer.sub
+++ b/htcosmos/infer.sub
@@ -24,8 +24,6 @@ require_gpus = $(require_gpus) && GlobalMemoryMb >= 8192
 # do a cpu-only run by clearing the GPU request
 if $(propose)
     use_cpu = 1
-elif $(post)
-    use_cpu = 1
 endif
 if $(use_cpu)
     request_gpus =
@@ -47,28 +45,14 @@ INFO_DIR = pages
 
 # This controls what temporary data we return in the INFO_DIR
 # This only filters *new* files. it has no effect on files already in the INFO_DIR
-KEEP_INFO=pickle
+KEEP_INFO=pickle,page,pad
 
 # paths to the model in the docker image. these will get put into the job environment
 MODEL_CONFIG=/configs/model_config.yaml
 WEIGHTS_PTH=/weights/model_weights.pth
-PP_WEIGHTS_PTH=/weights/pp_model_weights.pth
-AGGREGATIONS=pdfs,sections,tables,figures,equations
 
 # pass configuration info to the job in the environment
-env = ;MODEL_CONFIG=$(MODEL_CONFIG);WEIGHTS_PTH=$(WEIGHTS_PTH);PP_WEIGHTS_PTH=$(PP_WEIGHTS_PTH)
-env = $(env);AGGREGATIONS=$(AGGREGATIONS);KEEP_INFO=$(KEEP_INFO)
-
-# if the submit was invoked with propose=1 on the command line,
-# tell the script to quit after the propose step for each page
-# when JUST_PROPOSE is true, pickles and pages are always returned regardless of KEEP_INFO
-if $(propose)
-   env = $(env);JUST_PROPOSE=True
-elif $(infer)
-   env = $(env);SKIP_AGGREGATION=True
-elif $(post)
-   env = $(env);JUST_AGGREGATION=True
-endif
+env = ;MODEL_CONFIG=$(MODEL_CONFIG);WEIGHTS_PTH=$(WEIGHTS_PTH);KEEP_INFO=$(KEEP_INFO);SKIP_AGGREGATION=True
 
 # the actual job, the script will get copied from the submit machine
 # but we will use the python that is installed in the docker image
@@ -87,6 +71,6 @@ if $(append)
 endif
 output = $(CLUSTERID).out
 error = $(CLUSTERID).err
-log = parquet.log
+log = infer.log
 
 queue

--- a/htcosmos/post.sub
+++ b/htcosmos/post.sub
@@ -4,34 +4,12 @@ universe = docker
 # processing propose typically uses about 3.5 GB of CPU memory and 8GB of GPU memory
 # add cpus=xx disk=yy memory=zz on the submit command line to override these defaults
 request_disk = $(disk:500MB)
-request_memory = $(memory:6GB)
+request_memory = $(memory:2GB)
 request_cpus = $(cpus:1)
-request_gpus = 1
-require_gpus = GlobalMemoryMb >= 8192
 
 # choose a docker image, by default we will use the newer one
 # the image then implies a GPU capability requirement
-if $(older_docker_image)
-  docker_image = uwcosmos/cosmos-ingestion
-  require_gpus = $(require_gpus) && capability >= 3.7 && capability <= 7.5
-else
-  docker_image = uwcosmos/cosmos-ingestion-c11
-  require_gpus = $(require_gpus) && capability > 3.7
-endif
-require_gpus = $(require_gpus) && GlobalMemoryMb >= 8192
-
-# if the submit was invoked with use_cpu=1, or propose=1 on the command line
-# do a cpu-only run by clearing the GPU request
-if $(propose)
-    use_cpu = 1
-elif $(post)
-    use_cpu = 1
-endif
-if $(use_cpu)
-    request_gpus =
-    require_gpus =
-    request_cpus = 1
-endif
+docker_image = uwcosmos/cosmos-ingestion
 
 # tell CHTC pool that we want to match backfill resources
 +WantFlocking=true
@@ -51,24 +29,12 @@ KEEP_INFO=pickle
 
 # paths to the model in the docker image. these will get put into the job environment
 MODEL_CONFIG=/configs/model_config.yaml
-WEIGHTS_PTH=/weights/model_weights.pth
 PP_WEIGHTS_PTH=/weights/pp_model_weights.pth
 AGGREGATIONS=pdfs,sections,tables,figures,equations
 
 # pass configuration info to the job in the environment
-env = ;MODEL_CONFIG=$(MODEL_CONFIG);WEIGHTS_PTH=$(WEIGHTS_PTH);PP_WEIGHTS_PTH=$(PP_WEIGHTS_PTH)
-env = $(env);AGGREGATIONS=$(AGGREGATIONS);KEEP_INFO=$(KEEP_INFO)
-
-# if the submit was invoked with propose=1 on the command line,
-# tell the script to quit after the propose step for each page
-# when JUST_PROPOSE is true, pickles and pages are always returned regardless of KEEP_INFO
-if $(propose)
-   env = $(env);JUST_PROPOSE=True
-elif $(infer)
-   env = $(env);SKIP_AGGREGATION=True
-elif $(post)
-   env = $(env);JUST_AGGREGATION=True
-endif
+env = ;MODEL_CONFIG=$(MODEL_CONFIG);PP_WEIGHTS_PTH=$(PP_WEIGHTS_PTH);AGGREGATIONS=$(AGGREGATIONS)
+env = $(env);JUST_AGGREGATION=True;KEEP_INFO=$(KEEP_INFO:no)
 
 # the actual job, the script will get copied from the submit machine
 # but we will use the python that is installed in the docker image
@@ -87,6 +53,6 @@ if $(append)
 endif
 output = $(CLUSTERID).out
 error = $(CLUSTERID).err
-log = parquet.log
+log = post.log
 
 queue

--- a/htcosmos/processing_time.pl
+++ b/htcosmos/processing_time.pl
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+my %times;
+my %remains;
+my $tp;
+my $t;
+my $td;
+foreach my $line (<STDIN>) {
+   my ($time,$msg) = $line =~ m{^(\S+)\s(.*)$};
+   next if ( ! defined $time);
+   my ($h,$m,$s,$ms) = $time =~ m{(\d\d):(\d\d):(\d\d).(\d\d\d)};
+   if (defined $h) {
+      $t = ((($h*60)+$m)*60)+$s+($ms/1000.0);
+      $td = 0.0; if (defined $tp) { $td = $t - $tp; }
+      $tp = $t;
+#      printf "%8.3f %6.1fs\t%s\n",$t,$td,$msg;
+   }
+   
+   my ($tag,$r) = $msg =~ m{^(\S+\s+\S+)\s+(.*)$};
+   if (defined $tag) {
+      $tag =~ s/\d+//g;
+      $times{$tag} += $td;
+      $remains{$tag} = $r;
+   }
+
+}
+
+print "\n------\n";
+
+my $tot = 0.0;
+if (%times) {
+   for (sort keys %times) {
+      $tot += $times{$_};
+      printf "%-25s %8.3f (%s)\n", $_,$times{$_},$remains{$_};
+   }
+}
+print  "------------------------- --------\n";
+printf "%-25s %8.3f (%.3f min)\n", "total",$tot,$tot/60.0;

--- a/htcosmos/propose.sub
+++ b/htcosmos/propose.sub
@@ -18,7 +18,7 @@ OUT_DIR = output
 INFO_DIR = pages
 
 # use the environment to tell the script to just make PNG files and propose
-env = ;JUST_PROPOSE=True;KEEP_INFO=page,pickle
+env = ;JUST_PROPOSE=True;KEEP_INFO=page,pickle,pad
 
 SCRIPT = make_parquet.py
 executable = /usr/bin/python3.8
@@ -30,6 +30,9 @@ transfer_output_files = $(OUT_DIR), $(INFO_DIR)
 should_transfer_files = YES
 when_to_transfer_output = ON_EXIT_OR_EVICT
 
+if $(append)
+   erase_output_and_error_on_restart = false
+endif
 output = $(CLUSTERID).out
 error = $(CLUSTERID).err
 log = propose.log

--- a/htcosmos/times
+++ b/htcosmos/times
@@ -1,0 +1,2 @@
+#!/bin/bash
+egrep "process|print|parse|get prop|inference|padded to|created|database" $1 | grep -v '\-\-\-' | grep -v "and files" | ./processing_time.pl


### PR DESCRIPTION
    Process pages in order (glob, then sort)
    Do inference (GPU model) processing for all pages of a PDF before aggregation of the pages
    Create files that indicate partial completion of processing a PDF file
    Skip steps of processing a PDF when a completion file exists in the pages directory

Add two new submit files for submitting a HTCondor workflow
    infer.sub  - process up to the GPU inference model and return pickles and pages
    post.sub   - aggreggate the results of the GPU inference model and make parquet files

Add a simple perl script to scrape the stdout from the make_parquet.py and print elapsed times for the steps.
a bit hacky, code expert needed necessary to interpret the output ;)