### PR TITLE
Return one, both, or neither extractions upon success

### DIFF
--- a/cosmos/ingestion/ingest/utils/table_extraction.py
+++ b/cosmos/ingestion/ingest/utils/table_extraction.py
@@ -162,7 +162,6 @@ class TableLocation:
             log += f'Pdfplumber extract failed: {e}\n{self.pdf_path}\n{self.pdfplumber_page}\n{self.pdfplumber_table_area}\n'
 
         if camelot_success or pdfplumber_success:
-            print(log)
             return [camelot_df, pdfplumber_df], log, report, table
         else:
             logging.error(log)

--- a/cosmos/ingestion/ingest/utils/table_extraction.py
+++ b/cosmos/ingestion/ingest/utils/table_extraction.py
@@ -144,7 +144,7 @@ class TableLocation:
                                      table_areas=self.camelot_table_area,
                                      flavor='stream'
                                      )
-            dcamelot_dff = table[0].df
+            camelot_df = table[0].df
             report = table[0].parsing_report
             camelot_success = True
             log += 'Camelot table extracted\n'


### PR DESCRIPTION
Addressed two issues #178 and #177 related to `table_extraction.py`

For #178 , added a condition check for `camelot_success` or `pdfplumber_success`, so that there are 3 cases (below are printed logs during testing, the print statement was removed before creating this PR):

1. If both Camelot and Pdfplumber succeeded
```
Working on /pdfs/5ef119afa58f1dfd5209bd33.pdf
Camelot table extracted
Pdfplumber table extracted
```
2. If either Camelot or Pdfplumber failed 
```
Working on /pdfs/5ef119afa58f1dfd5209bd33.pdf
Camelot table extracted
Pdfplumber extract failed: 'NoneType' object is not subscriptable
/pdfs/5ef119afa58f1dfd5209bd33.pdf
2
(305, 397, 558, 614)
```
3. If both Camelot and Pdfplumber failed
```
Working on /pdfs/620ddab8ad0e9c819b0a07a0.pdf
WARNING:root:camelot co-ords with negative y: 620ddab8ad0e9c819b0a07a0.pdf
/usr/local/lib/python3.7/site-packages/camelot/parsers/stream.py:449: UserWarning: page-36 is image-based, camelot only works on text-based pages.
  f"{base_filename} is image-based, camelot only works on"
WARNING:root:camelot co-ords with negative y: 620ddab8ad0e9c819b0a07a0.pdf
ERROR:root:Camelot extract failed: list index out of range
/pdfs/620ddab8ad0e9c819b0a07a0.pdf
36
['0,0,642,595']
Pdfplumber extract failed: Bounding box (0, 0, 642, 823) is not fully within parent page bounding box (0, 0, 612, 800.64)
/pdfs/620ddab8ad0e9c819b0a07a0.pdf
35
(0, 0, 642, 823)
```

For #177 , now both AttributeError and TypeError are caught. Please see #177 for details 
