### PR TITLE
XDD-161: Add new aggregation step to repartition equation images based on their equation-number label

### DIFF
--- a/cosmos/ingestion/ingest/process/aggregation/aggregate.py
+++ b/cosmos/ingestion/ingest/process/aggregation/aggregate.py
@@ -3,13 +3,12 @@ import functools
 from PIL import Image
 import uuid
 import os
-
+from .reaggregate_equations import split_equation_system
 
 def check_y_overlap(bb1, bb2):
     _, x1, _, x2 = bb1
     _, y1, _, y2 = bb2
     return y2 >= x1 and x2 >= x1
-
 
 def aggregate_equations(page_group, write_images_pth):
     targets = []
@@ -22,19 +21,23 @@ def aggregate_equations(page_group, write_images_pth):
     page_content = ' '.join([p['content'] for p in objs])
     final_objs = []
     for t in targets:
-        img = Image.open(t['img_pth']).convert('RGB').crop(t['bounding_box'])
-        imgid = uuid.uuid4()
-        pth = os.path.join(write_images_pth, f'{imgid}.png')
-        img.save(pth)
-        eq_obj = {'pdf_name': t['pdf_name'],
-                  'dataset_id': t['dataset_id'],
-                  'detect_score': t['detect_score'],
-                  'postprocess_score': t['postprocess_score'],
-                  'equation_bb': t['bounding_box'],
-                  'equation_page': t['page_num'],
-                  'content': page_content,
-                  'img_pth': pth}
-        final_objs.append(eq_obj)
+        img, padded_bounds, sub_regions = split_equation_system(t)
+        left, top, *_ = padded_bounds
+        for region in sub_regions:
+            sub_img = img.crop(region)
+            full_page_bounds = (region.left + left, region.top + top, region.right + left, region.bottom + top)
+            imgid = uuid.uuid4()
+            pth = os.path.join(write_images_pth, f'{imgid}.png')
+            sub_img.save(pth)
+            eq_obj = {'pdf_name': t['pdf_name'],
+                    'dataset_id': t['dataset_id'],
+                    'detect_score': t['detect_score'],
+                    'postprocess_score': t['postprocess_score'],
+                    'equation_bb': full_page_bounds,
+                    'equation_page': t['page_num'],
+                    'content': page_content,
+                    'img_pth': pth}
+            final_objs.append(eq_obj)
     return final_objs
 
 

--- a/cosmos/ingestion/ingest/process/aggregation/reaggregate_equations.py
+++ b/cosmos/ingestion/ingest/process/aggregation/reaggregate_equations.py
@@ -1,0 +1,90 @@
+"""
+Helper functions that try to extract the individual equations
+out of an equation-labeled image segment
+"""
+from typing import List, Tuple, Dict
+from collections import namedtuple
+from ..proposals.connected_components import get_proposals
+from PIL import Image
+
+
+RIGHT_JUSTIFY_EDGE = 15 # Farthest from an image's right edge that a label can be
+LABEL_MAX_WIDTH = 60 # Max width of a label
+LABEL_MAX_HEIGHT = 40 # Max height of a label
+PADDING = 5 # Pad the very narrowly cropped equation segments back out a bit
+
+# Convenience class to assign property names to the 4 tuple of ints used for segment coordinates
+Bounds = namedtuple("Bounds", ("left", "top", "right", "bottom"))
+
+def middle(bounds: Bounds):
+    """Get the vertical center of a Bounds"""
+    return (bounds.top + bounds.bottom) / 2
+
+def pad(bound: Bounds, padding: int = PADDING):
+    """Pad a Bounds by expanding it slightly on all sides"""
+    return Bounds(
+        bound.left - padding,
+        bound.top - padding,
+        bound.right + padding,
+        bound.bottom + padding 
+    )
+
+def is_label(img_width: int, bounds: Bounds):
+    """
+    Identify equation image segments that are probably equation number labels based on their
+    width, height, and proximity to the right edge of the image
+    """
+    return (bounds.right >= img_width - RIGHT_JUSTIFY_EDGE and 
+            bounds.right - bounds.left <= LABEL_MAX_WIDTH and 
+            bounds.bottom - bounds.top <= LABEL_MAX_HEIGHT)
+
+
+def group_equations_by_nearest_label(img_width: int, segments: List[Bounds]):
+    """
+    Re-group an equation image that was partitioned along a very narrow whitespace margin.
+    Identify the labels in the equation system based on their right-justification,
+    then group all other segments of the equation by their nearest label-identified segment
+    """
+
+    named_segments = [Bounds(*s) for s in segments]
+
+    label_segments = [s for s in named_segments if is_label(img_width, s)]
+    # label images can be excluded from final bounds
+    non_label_segments = [s for s in named_segments if not is_label(img_width, s)]
+
+    # backup in case there are no labels in the image
+    if len(label_segments) == 0:
+        label_segments.append(Bounds(0, 0, 0, 0))
+
+    label_groups : Dict[Bounds, List[Bounds]] = {s: [] for s in label_segments}
+
+    for segment in non_label_segments:
+        # find the nearest vertical label
+        nearest_label = sorted(label_segments, key = lambda ls: abs(middle(ls) - middle(segment)))[0]
+        label_groups[nearest_label].append(segment)
+
+    grouped_bounds = [
+        Bounds(
+            min([s.left for s in sg]),
+            min([s.top for s in sg]),
+            max([s.right for s in sg]),
+            max([s.bottom for s in sg])
+        )
+        for sg in label_groups.values()
+    ]
+
+    padded_bounds = [pad(b) for b in grouped_bounds]
+
+    return padded_bounds
+
+def split_equation_system(target) -> Tuple[Image.Image, Bounds, List[Bounds]]:
+    """
+    Propose sub-images for an equation-labeled image, which frequently contain multiple equations
+    """
+    # TODO make this behavior toggle-able
+    padded_bb = pad(Bounds(*target['bounding_box']))
+    img_base = Image.open(target['img_pth']).convert('RGB').crop(padded_bb)
+    # Systems of equations are frequently closely grouped, need to find regions again with a
+    # smaller whitespace margin
+    all_sub_regions = get_proposals(img_base, blank_row_height=3, max_obj_count=50)
+    return img_base, padded_bb, group_equations_by_nearest_label(img_base.width, all_sub_regions)

--- a/deployment/ingestion.Dockerfile
+++ b/deployment/ingestion.Dockerfile
@@ -9,6 +9,8 @@ RUN chmod +x /cli/ingest_documents.sh
 
 COPY cosmos/ingestion /ingestion
 WORKDIR /ingestion
+# TODO this should probably go in cosmos-base, but there are some additional dependency issues to untangle there
+RUN apt-get update && apt-get install -y pkg-config && python3.8 -m pip install pdfplumber
 RUN python3.8 -m pip install .
 ENV PYTHONPATH ".:${PYTHONPATH}"
 


### PR DESCRIPTION
Adds a new step in aggregation that re-partitions equation identified images into smaller segments. Attempts to find equation number labels based on their position to the right edge of the image, then groups other segments based on their nearest equation label