### PR TITLE
bugfix: handle non segmentable equations

### DIFF
--- a/cosmos/ingestion/ingest/process/aggregation/reaggregate_equations.py
+++ b/cosmos/ingestion/ingest/process/aggregation/reaggregate_equations.py
@@ -56,6 +56,11 @@ def group_equations_by_nearest_label(img_width: int, segments: List[Bounds]):
     if len(label_segments) == 0:
         label_segments.append(Bounds(0, 0, 0, 0))
 
+    # If the whole image was flagged as a label for some reason, treat the labels as non-labels
+    if len(non_label_segments) == 0:
+        non_label_segments = label_segments
+
+
     label_groups : Dict[Bounds, List[Bounds]] = {s: [] for s in label_segments}
 
     for segment in non_label_segments:
@@ -70,7 +75,7 @@ def group_equations_by_nearest_label(img_width: int, segments: List[Bounds]):
             max([s.right for s in sg]),
             max([s.bottom for s in sg])
         )
-        for sg in label_groups.values()
+        for sg in label_groups.values() if len(sg)
     ]
 
     padded_bounds = [pad(b) for b in grouped_bounds]

--- a/cosmos_service/src/process.py
+++ b/cosmos_service/src/process.py
@@ -52,7 +52,7 @@ def process_document(pdf_dir: str, job_id: str, compress_images: bool = True):
             shutil.make_archive(archive_out_dir, "zip", cosmos_out_dir)
         except Exception as e:
             cosmos_error = e
-            print("Cosmos processing failed:\n", cosmos_error, flush=True)
+            logger.exception("Cosmos processing failed", flush=True)
 
         is_oom_error = cosmos_error and any([e in str(cosmos_error) for e in OOM_ERROR_MESSAGES])
 


### PR DESCRIPTION
- handle the scenario where all of the subsegments of an equation are flagged as labels

An error was occurring when equation sub-segmentation flagged the whole equation as a label and then tried to generate an empty non-label bounding box, this change makes it so that the "label" segment is switched to a non-label if it's the only segment.