### PR TITLE
xDD-172: Cosmos service docs

### DIFF
--- a/cosmos_service/src/app.py
+++ b/cosmos_service/src/app.py
@@ -15,7 +15,7 @@ from util.cosmos_output_utils import extract_file_from_job, convert_parquet_to_j
 from model.models import *
 import shutil
 
-prefix_url = os.environ.get('API_PREFIX','/')
+prefix_url = os.environ.get('API_PREFIX','/cosmos_service')
 
 app = FastAPI(title="COSMOS Service", docs_url=f"{prefix_url}/docs")
 

--- a/cosmos_service/src/model/models.py
+++ b/cosmos_service/src/model/models.py
@@ -1,6 +1,4 @@
 from pydantic import BaseModel, Field, HttpUrl
-from dataclasses import dataclass
-from fastapi import File, UploadFile, Form
 from typing import Tuple
 from enum import Enum
 
@@ -42,9 +40,3 @@ class ExtractionType(Enum):
     Equations = "equations"
     Tables = "tables"
     Figures = "figures"
-
-@dataclass
-class JobCreationRequest:
-    pdf: UploadFile = File(..., description="The document to process with COSMOS", media_type="application/pdf"), 
-    compress_images: bool = Form(True, description="Whether to generate compressed or full-resolution images of extractions"), 
-    use_cache: bool = Form(True, description="Whether to reuse cached results for the given PDF")

--- a/cosmos_service/src/model/models.py
+++ b/cosmos_service/src/model/models.py
@@ -1,0 +1,50 @@
+from pydantic import BaseModel, Field, HttpUrl
+from dataclasses import dataclass
+from fastapi import File, UploadFile, Form
+from typing import Tuple
+from enum import Enum
+
+# Response Models
+
+class JobCreationResponse(BaseModel):
+    message: str = Field(..., description="Message indicating whether a job was created or retrieved from the cache successfully")
+    job_id: str = Field(..., description="ID of the created or retrieved job")
+    status_endpoint: HttpUrl = Field(..., description="Endpoint for polling the status of an in-progress job")
+    results_endpoint: HttpUrl = Field(..., description="Endpoint for retrieving the results of a completed job")
+
+class JobStatus(BaseModel):
+    job_started: bool = Field(..., description="Whether the job has started running on a GPU")
+    job_completed: bool = Field(..., description="Whether the job has competed successfully")
+    error: str = Field(..., description="Whether the job has failed with an error")
+    time_in_queue: float = Field(...,description="Time the job was queued before running")
+    time_processing: float = Field(...,description="Time the job has spent running on a GPU")
+
+class CosmosJSONBaseResponse(BaseModel):
+    pdf_name: str = Field(..., description="Name of the PDF the item was extracted from")
+    page_num: str = Field(..., description="Page in the PDF the item was extracted from")
+    bounding_box: Tuple[int, int, int, int] = Field(..., description="Coordinates of the extracted item on its page")
+    detect_score: float = Field(..., description="Initial confidence in the label given to the extracted item")
+    postprocess_score: float = Field(..., description="Confidence in the label given to the extracted item after post-processing")
+
+
+class CosmosJSONImageResponse(CosmosJSONBaseResponse):
+    img_pth: HttpUrl = Field(..., description="Temporary URL from which the extracted image can be retrieved")
+
+class CosmosJSONTextResponse(CosmosJSONBaseResponse):
+    content: str = Field(...,description="The extracted text")
+    detect_cls: str = Field(..., description="Initial label given to the extracted item")
+    postprocess_cls: float = Field(..., description="Label given to the extracted item after post-processing")
+
+
+# Request Models
+
+class ExtractionType(Enum):
+    Equations = "equations"
+    Tables = "tables"
+    Figures = "figures"
+
+@dataclass
+class JobCreationRequest:
+    pdf: UploadFile = File(..., description="The document to process with COSMOS", media_type="application/pdf"), 
+    compress_images: bool = Form(True, description="Whether to generate compressed or full-resolution images of extractions"), 
+    use_cache: bool = Form(True, description="Whether to reuse cached results for the given PDF")


### PR DESCRIPTION
- Update the route that FastAPI documentation is hosted at so that it's accessible from the k8s ingress path prefix
- Replace python dicts with data classes so that FastAPI's doc auto-generation feature picks up on them