### PR TITLE
XDD-207: Intersection over Union/Mean Average Precision

### DIFF
--- a/cosmos_service/src/healthcheck/annotation_metrics.py
+++ b/cosmos_service/src/healthcheck/annotation_metrics.py
@@ -7,7 +7,7 @@ from .page_metrics import PageAnnotationComparison, DocumentAnnotationComparison
 import pandas as pd
 from typing import List
 
-AREA_BOUNDS=(0.9,1.1)
+AREA_BOUNDS=(0.9,1.0)
 DEFAULT_REGION_TYPES = ["Figure", "Equation", "Table"]
 
 

--- a/cosmos_service/src/healthcheck/annotation_metrics.py
+++ b/cosmos_service/src/healthcheck/annotation_metrics.py
@@ -25,8 +25,8 @@ class AnnotationComparator:
 
         for m1 in self.cosmos_annotations:
             for m2 in self.cosmos_annotations:
-                if m1.overlap(m2) > 0 and m1.page_num == m2.page_num and m1.postprocess_cls == m2.postprocess_cls and m1 != m2:
-                    print(m1.bounding_box, m2.bounding_box, m1.overlap(m2))
+                if m1.intersection(m2) > 0 and m1.page_num == m2.page_num and m1.postprocess_cls == m2.postprocess_cls and m1 != m2:
+                    print(m1.bounding_box, m2.bounding_box, m1.intersection(m2))
 
 
     def _read_cosmos_parquet(self, parquet_file, bb_label='bounding_box'):

--- a/cosmos_service/src/healthcheck/annotation_metrics.py
+++ b/cosmos_service/src/healthcheck/annotation_metrics.py
@@ -61,7 +61,7 @@ class AnnotationComparator:
             *[c for c in cosmos_annotations if c['postprocess_cls'] != 'Equation'],
             *equation_annotations
         ]
-        return [AnnotationBounds.parse_obj(sb) for sb in spliced_bounds]
+        return [AnnotationBounds.model_validate(sb) for sb in spliced_bounds]
 
 
     def _get_labeled_item_per_page(self, annotations: List[AnnotationBounds], label_class: str, page: int):
@@ -78,5 +78,5 @@ class AnnotationComparator:
             self._compare_area_bounds_per_page(label_class, page_num)
             for page_num in range(1, page_count+1) # 1-indexed
         ]
-
-        return DocumentAnnotationComparison(page_comparisons=page_comparisons, label_class=label_class)
+        non_empty_pages = [p for p in page_comparisons if p.expected_count > 0 or p.cosmos_count > 0]
+        return DocumentAnnotationComparison(page_comparisons=non_empty_pages, label_class=label_class)

--- a/cosmos_service/src/healthcheck/page_metrics.py
+++ b/cosmos_service/src/healthcheck/page_metrics.py
@@ -2,10 +2,16 @@
 
 from pydantic import BaseModel, Field, computed_field
 from typing import List
+from numpy import arange
+
+AP_THRESH = arange(0.5,1,0.05) # average of all precisions from 0.5 to 0.95 in 0.05 increments
+AP50_THRESH = [0.5]
+AP75_THRESH = [0.75]
 
 class AnnotationBounds(BaseModel):
     page_num: int = Field(description="Page Number")
     postprocess_cls: str = Field(description="The label assigned to the region by Cosmos")
+    postprocess_score: float = 0 # for internal use only
     bounding_box: List[int] = Field(description="Region bounds (x0, y0, x1, y1)")
 
     def area(self):
@@ -43,32 +49,77 @@ class PageAnnotationComparison(BaseModel):
 
     expected_area: int = Field(description="Expected area of regions with the given label on the page")
     cosmos_area: int = Field(description="Area of regions with the given label identified by COSMOS on the page")
-    average_iou: float = Field(description="Average intersection-over-union for all expected regions on the page")
-    max_ious: List[float] = Field(exclude=True) # for internal use only
+    average_precision: float = Field(description="Average precision of the COSMOS-identified regions on the page")
+    ap50: float = Field(description="Precision of the COSMOS-identified regions on the page with a 0.5 iou threshold")
+    ap75: float = Field(description="Precision of the COSMOS-identified regions on the page with a 0.75 iou threshold")
+    ious: List[float] = Field(exclude=True) # for internal use only
+    postprocess_scores: List[float] = Field(exclude=True) # for internal use only
 
     @computed_field(description="Whether the correct count of regions was identified by COSMOS")
     @property
     def count_in_bounds(self) -> bool:
         return self.expected_count == self.cosmos_count
 
-    @computed_field(description=f"Whether over 90% of the expected area was identified by COSMOS")
-    @property
-    def iou_in_bounds(self) -> bool:
-        return self.average_iou >= 0.9
+    @staticmethod
+    def _average_precision_score(true_labels, scores):
+        """ Approximate the area under the (precision, recall) curve for the given set of labels, 
+        ordered by confidence score. 
+        https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision
+        """
+        
+        # sort the true labels according to their confidence score, descending
+        sorted_true_labels = [label for score, label in sorted(zip(scores, true_labels), reverse=True)]
+        total_true_count = sum(sorted_true_labels)
 
+        if total_true_count == 0:
+            return 0
+
+        # Calculate (recall, precision) coordinates at each step of the array
+        rc_pairs = []
+        for i,_ in enumerate(sorted_true_labels):
+            correct_sum = sum(sorted_true_labels[:i+1])
+            recall = correct_sum / total_true_count
+            precision = correct_sum / (i + 1)
+            rc_pairs.append((recall, precision))
+        
+        # Approximate the area under the curve as the sum of precision * delta_recall
+        precision_sum = 0
+        previous_recall = 0
+        for recall, precision in rc_pairs:
+            delta_recall = recall - previous_recall
+            precision_sum += precision * delta_recall
+            previous_recall = recall
+        
+        return precision_sum
+            
 
     @staticmethod
-    def _average_iou(expected_bounds: List[AnnotationBounds], actual_bounds: List[AnnotationBounds]):
-        if len(expected_bounds) == 0 and len(actual_bounds) == 0:
-            return {'max_ious': [], 'average_iou': 1}
-        elif len(expected_bounds) == 0 or len(actual_bounds) == 0:
-            return {'max_ious': [0 for _ in expected_bounds], 'average_iou': 0}
+    def _precision_at_thresholds(ious: List[float], scores: List[float], thresholds: List[float]):
+        if len(ious) == 0:
+            return 0
+        all_precisions = []
+        for thresh in thresholds:
+            true_labels = [i >= thresh for i in ious]
+            all_precisions.append(PageAnnotationComparison._average_precision_score(true_labels, scores))
+
+        return sum(all_precisions) / len(all_precisions)
+
+    @staticmethod
+    def _average_precisions(expected_bounds: List[AnnotationBounds], actual_bounds: List[AnnotationBounds]):
+        # Sort bounds in order of confidence
+
+        if len(actual_bounds) == 0 or len(expected_bounds) == 0:
+            return {'ious': [], 'postprocess_scores': [], 'average_precision': 0, 'ap50': 0, 'ap75': 0}
         # For each expected bound, find the best i-o-u ratio from among the cosmos bounds on the same page
-        max_ious = [max(e.intersection_over_union(a) for a in actual_bounds) for e in expected_bounds]
+        ious = [max(e.intersection_over_union(a) for e in expected_bounds) for a in actual_bounds]
+        postprocess_scores = [a.postprocess_score for a in actual_bounds]
         # return the average of all the best i-o-us on the page
         return {
-            'max_ious': max_ious,
-            'average_iou': sum(max_ious) / len(expected_bounds)
+            'ious': ious,
+            'postprocess_scores': postprocess_scores,
+            'average_precision': PageAnnotationComparison._precision_at_thresholds(ious, postprocess_scores, AP_THRESH),
+            'ap50': PageAnnotationComparison._precision_at_thresholds(ious, postprocess_scores, AP50_THRESH),
+            'ap75': PageAnnotationComparison._precision_at_thresholds(ious, postprocess_scores, AP75_THRESH),
         }
 
     @staticmethod
@@ -79,7 +130,7 @@ class PageAnnotationComparison(BaseModel):
             cosmos_count=len(actual_bounds),
             expected_area=sum(e.area() for e in expected_bounds),
             cosmos_area=sum(a.area() for a in actual_bounds),
-            **PageAnnotationComparison._average_iou(expected_bounds, actual_bounds)
+            **PageAnnotationComparison._average_precisions(expected_bounds, actual_bounds)
         )
 
 class DocumentAnnotationComparison(BaseModel):
@@ -97,18 +148,28 @@ class DocumentAnnotationComparison(BaseModel):
     def document_cosmos_count(self) -> int:
         return sum([p.cosmos_count for p in self.page_comparisons])
 
-    @computed_field(description="The average of every intersection-over-union for the expected regions in the document")
-    @property
-    def document_average_iou(self) -> float:
-        all_ious = sum([p.max_ious for p in self.page_comparisons], [])
-        return sum(all_ious) / len(all_ious)
-
     @computed_field(description="Whether the correct count of regions was identified by COSMOS")
     @property
     def count_in_bounds(self) -> bool:
         return self.document_expected_count == self.document_cosmos_count
 
-    @computed_field(description=f"Whether over 90% of the expected area was identified by COSMOS")
+    @computed_field(description="The average precision of every COSMOS-identified region in the document")
     @property
-    def iou_in_bounds(self) -> bool:
-        return self.document_average_iou >= 0.9
+    def average_precision(self) -> float:
+        all_ious = sum([p.ious for p in self.page_comparisons], [])
+        all_postprocess_scores = sum([p.postprocess_scores for p in self.page_comparisons], [])
+        return PageAnnotationComparison._precision_at_thresholds(all_ious, all_postprocess_scores, AP_THRESH)
+
+    @computed_field(description="The precision of every COSMOS-identified region in the document with a 0.5 iou threshold")
+    @property
+    def ap50(self) -> float:
+        all_ious = sum([p.ious for p in self.page_comparisons], [])
+        all_postprocess_scores = sum([p.postprocess_scores for p in self.page_comparisons], [])
+        return PageAnnotationComparison._precision_at_thresholds(all_ious, all_postprocess_scores, AP50_THRESH)
+
+    @computed_field(description="The precision of every COSMOS-identified region in the document with a 0.75 iou threshold")
+    @property
+    def ap75(self) -> float:
+        all_ious = sum([p.ious for p in self.page_comparisons], [])
+        all_postprocess_scores = sum([p.postprocess_scores for p in self.page_comparisons], [])
+        return PageAnnotationComparison._precision_at_thresholds(all_ious, all_postprocess_scores, AP75_THRESH)

--- a/cosmos_service/src/routers/healthcheck.py
+++ b/cosmos_service/src/routers/healthcheck.py
@@ -11,7 +11,15 @@ router = APIRouter(prefix="/healthcheck")
 @router.post("/evaluate/{job_id}")
 def evaluate_results(job_id: str, expected_bounds: List[AnnotationBounds]) -> List[DocumentAnnotationComparison]:
     """
-    Evaluate the results of a recently-run COSMOS job against a list of expected region bounding boxes
+    Evaluate the results of a recently-run COSMOS job against a list of expected region bounding boxes. For each of the 3 region label classes,
+    the [average precision score](https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision) is calculated
+    according to the following procedure:
+
+    * For each threshold between 50% and 95%, in 5% intervals:
+    * Label each Cosmos extraction as a true positive if its intersection-over-union with a ground truth region is greater than the threshold
+    * Compute the [average precision](https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision) of the set of extractions at the given threshold
+      * Average Precision is a measure of the change in precision and recall of the model as results with lower confidence scores are considered
+    * Average the average precision score from each i-o-u threshold
     """
     job = get_job_details(job_id)
     comparator = AnnotationComparator(read_job_zip_file(job), expected_bounds)
@@ -23,7 +31,15 @@ def evaluate_results(
     cosmos_output: UploadFile = File(..., description="Any COSMOS output file", media_type="application/pdf"), 
     expected_bounds: str = Form(..., description="JSON object containing expected annotation bounds")) -> List[DocumentAnnotationComparison]:
     """
-    Evaluate the results of any COSMOS output against a list of expected region bounding boxes
+    Evaluate the results of any COSMOS output against a list of expected region bounding boxes. For each of the 3 region label classes,
+    the [average precision score](https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision) is calculated
+    according to the following procedure:
+
+    * For each threshold between 50% and 95%, in 5% intervals:
+    * Label each Cosmos extraction as a true positive if its intersection-over-union with a ground truth region is greater than the threshold
+    * Compute the [average precision](https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision) of the set of extractions at the given threshold
+      * Average Precision is a measure of the change in precision and recall of the model as results with lower confidence scores are considered
+    * Average the average precision score from each i-o-u threshold
     """
     # FastAPI doesn't support parsing JSON directly out of multipart forms, so do it manually
     bounds = [AnnotationBounds.model_validate(b) for b in json.loads(expected_bounds)]

--- a/cosmos_service/test/src/annotations/annotations_base.py
+++ b/cosmos_service/test/src/annotations/annotations_base.py
@@ -9,7 +9,7 @@ import pandas as pd
 from zipfile import ZipFile
 from ..util.cosmos_client import submit_pdf_to_cosmos, poll_for_cosmos_output
 from ....src.healthcheck.annotation_metrics import AnnotationComparator, AnnotationBounds, AREA_BOUNDS, DEFAULT_REGION_TYPES
-from .error_printer import DocumentExpectedCountPrinter, DocumentIntersectionOverUnionPrinter
+from .error_printer import DocumentExpectedCountPrinter, DocumentAveragePrecisionPrinter
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__),'../..'))
 
@@ -119,7 +119,7 @@ class BaseAnnotationComparisonTest:
 
     def check_overlap_per_page(self, label_class):
         comparison = self.comparator.compare_for_label(label_class)
-        failures = DocumentIntersectionOverUnionPrinter(f"{label_class} mean intersection-over-union", comparison.page_comparisons)
+        failures = DocumentAveragePrecisionPrinter(f"{label_class} average precision", comparison.page_comparisons)
         assert failures.ok(), failures.error_message()
 
     def check_document_count(self, label_class):
@@ -129,6 +129,6 @@ class BaseAnnotationComparisonTest:
 
     def check_document_overlap(self, label_class):
         comparison = self.comparator.compare_for_label(label_class)
-        assert comparison.iou_in_bounds, \
-            f"Incorrect {label_class} mean intersection-over-union: expected={AREA_BOUNDS} actual={comparison.document_average_iou}"
+        assert comparison.average_precision > AREA_BOUNDS[0], \
+            f"Incorrect {label_class} average precision: expected={AREA_BOUNDS} actual={comparison.average_precision}"
 

--- a/cosmos_service/test/src/annotations/annotations_base.py
+++ b/cosmos_service/test/src/annotations/annotations_base.py
@@ -9,7 +9,7 @@ import pandas as pd
 from zipfile import ZipFile
 from ..util.cosmos_client import submit_pdf_to_cosmos, poll_for_cosmos_output
 from ....src.healthcheck.annotation_metrics import AnnotationComparator, AnnotationBounds, AREA_BOUNDS, DEFAULT_REGION_TYPES
-from .error_printer import DocumentExpectedCountPrinter, DocumentExpectedOverlapPrinter
+from .error_printer import DocumentExpectedCountPrinter, DocumentIntersectionOverUnionPrinter
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__),'../..'))
 
@@ -119,7 +119,7 @@ class BaseAnnotationComparisonTest:
 
     def check_overlap_per_page(self, label_class):
         comparison = self.comparator.compare_for_label(label_class)
-        failures = DocumentExpectedOverlapPrinter(f"{label_class} overlap percentage", comparison.page_comparisons)
+        failures = DocumentIntersectionOverUnionPrinter(f"{label_class} mean intersection-over-union", comparison.page_comparisons)
         assert failures.ok(), failures.error_message()
 
     def check_document_count(self, label_class):
@@ -129,6 +129,6 @@ class BaseAnnotationComparisonTest:
 
     def check_document_overlap(self, label_class):
         comparison = self.comparator.compare_for_label(label_class)
-        assert comparison.overlap_in_bounds, \
-            f"Incorrect {label_class} bounds: expected={AREA_BOUNDS} actual={comparison.document_overlap_percent}"
+        assert comparison.iou_in_bounds, \
+            f"Incorrect {label_class} mean intersection-over-union: expected={AREA_BOUNDS} actual={comparison.document_average_iou}"
 

--- a/cosmos_service/test/src/annotations/error_printer.py
+++ b/cosmos_service/test/src/annotations/error_printer.py
@@ -18,8 +18,8 @@ class PageExpectedValuePrinter:
     def print_count_mismatch(self) -> str:
         return f"page {self.comparison.page}: expected={self.comparison.expected_count} actual={self.comparison.cosmos_count}"
 
-    def print_overlap_mismatch(self) -> str:
-        return f"page {self.comparison.page}: expected={AREA_BOUNDS} actual={self.comparison.overlap_percent}"
+    def print_iou_mismatch(self) -> str:
+        return f"page {self.comparison.page}: expected={AREA_BOUNDS} actual={self.comparison.average_iou}"
 
 class DocumentExpectedCountPrinter:
     """ Utility class for displaying all pages in a document for which the annotation count falls outside of the expected range """
@@ -36,17 +36,17 @@ class DocumentExpectedCountPrinter:
     def error_message(self):
         return f"Incorrect {self.comparison_type} on {len(self.page_values)} page(s)\n" + "\n".join([m.print_count_mismatch() for m in self.page_values])
 
-class DocumentExpectedOverlapPrinter:
+class DocumentIntersectionOverUnionPrinter:
     """ Utility class for displaying all pages in a document for which the annotation count falls outside of the expected range """
     page_values: list[PageExpectedValuePrinter]
     comparison_type: str
 
     def __init__(self, comparison_type, page_values: list[PageAnnotationComparison]):
-        self.page_values = [PageExpectedValuePrinter(p) for p in page_values if not p.overlap_in_bounds]
+        self.page_values = [PageExpectedValuePrinter(p) for p in page_values if not p.iou_in_bounds]
         self.comparison_type = comparison_type
 
     def ok(self):
         return len(self.page_values) == 0
     
     def error_message(self):
-        return f"Incorrect {self.comparison_type} on {len(self.page_values)} page(s)\n" + "\n".join([m.print_overlap_mismatch() for m in self.page_values])
+        return f"Incorrect {self.comparison_type} on {len(self.page_values)} page(s)\n" + "\n".join([m.print_iou_mismatch() for m in self.page_values])

--- a/cosmos_service/test/src/annotations/error_printer.py
+++ b/cosmos_service/test/src/annotations/error_printer.py
@@ -18,8 +18,8 @@ class PageExpectedValuePrinter:
     def print_count_mismatch(self) -> str:
         return f"page {self.comparison.page}: expected={self.comparison.expected_count} actual={self.comparison.cosmos_count}"
 
-    def print_iou_mismatch(self) -> str:
-        return f"page {self.comparison.page}: expected={AREA_BOUNDS} actual={self.comparison.average_iou}"
+    def print_average_precision_mismatch(self) -> str:
+        return f"page {self.comparison.page}: expected={AREA_BOUNDS} actual={self.comparison.average_precision}"
 
 class DocumentExpectedCountPrinter:
     """ Utility class for displaying all pages in a document for which the annotation count falls outside of the expected range """
@@ -36,17 +36,17 @@ class DocumentExpectedCountPrinter:
     def error_message(self):
         return f"Incorrect {self.comparison_type} on {len(self.page_values)} page(s)\n" + "\n".join([m.print_count_mismatch() for m in self.page_values])
 
-class DocumentIntersectionOverUnionPrinter:
+class DocumentAveragePrecisionPrinter:
     """ Utility class for displaying all pages in a document for which the annotation count falls outside of the expected range """
     page_values: list[PageExpectedValuePrinter]
     comparison_type: str
 
     def __init__(self, comparison_type, page_values: list[PageAnnotationComparison]):
-        self.page_values = [PageExpectedValuePrinter(p) for p in page_values if not p.iou_in_bounds]
+        self.page_values = [PageExpectedValuePrinter(p) for p in page_values if not p.average_precision >= AREA_BOUNDS[0]]
         self.comparison_type = comparison_type
 
     def ok(self):
         return len(self.page_values) == 0
     
     def error_message(self):
-        return f"Incorrect {self.comparison_type} on {len(self.page_values)} page(s)\n" + "\n".join([m.print_iou_mismatch() for m in self.page_values])
+        return f"Incorrect {self.comparison_type} on {len(self.page_values)} page(s)\n" + "\n".join([m.print_average_precision_mismatch() for m in self.page_values])

--- a/notebooks/cosmos-service/cosmos_service.ipynb
+++ b/notebooks/cosmos-service/cosmos_service.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "COSMOS_BASE_URL = \"http://cosmos0001.chtc.wisc.edu:8088/cosmos_service\"\n",
     "SAMPLE_PDF_URL = \"https://www.nature.com/articles/s41591-020-0883-7.pdf\"\n",
-    "SAMPLE_PDF_PATH = \"sidarthe.pdf\""
+    "SAMPLE_PDF_PATH = \"sidarthe.pdf\"\n"
    ]
   },
   {
@@ -40,7 +40,7 @@
     "# Download a local copy of the PDF\n",
     "\n",
     "with open(SAMPLE_PDF_PATH, 'wb') as pdf_writer:\n",
-    "    pdf_writer.write(requests.get(SAMPLE_PDF_URL).content)"
+    "    pdf_writer.write(requests.get(SAMPLE_PDF_URL).content)\n"
    ]
   },
   {
@@ -68,7 +68,7 @@
     "    print(f\"Message: {response_data['message']}\\n\"\n",
     "          f\"Job ID: {response_data['job_id']}\\n\"\n",
     "          f\"Status Endpoint: {status_endpoint}\\n\"\n",
-    "          f\"Results Endpoint: {results_endpoint}\")"
+    "          f\"Results Endpoint: {results_endpoint}\")\n"
    ]
   },
   {
@@ -111,7 +111,7 @@
     "    print(f\"An unexpected error occurred: {response_data['error']}\")\n",
     "else:\n",
     "    print(f\"Job succeeded after {response_data['time_processing']} seconds.\\n\"\n",
-    "          f\"Results can be viewed at {results_endpoint}\")"
+    "          f\"Results can be viewed at {results_endpoint}\")\n"
    ]
   },
   {
@@ -145,7 +145,7 @@
    "source": [
     "# Extracted document text and bounding boxes\n",
     "text_data = requests.get(f\"{results_endpoint}/text\")\n",
-    "print(json.dumps(text_data.json(), indent=2))"
+    "print(json.dumps(text_data.json(), indent=2))\n"
    ]
   },
   {
@@ -156,7 +156,7 @@
    "source": [
     "# Extracted document equations, bounding boxes, and images\n",
     "equation_data = requests.get(f\"{results_endpoint}/extractions/equations\")\n",
-    "print(json.dumps(equation_data.json(), indent=2))"
+    "print(json.dumps(equation_data.json(), indent=2))\n"
    ]
   },
   {
@@ -167,7 +167,7 @@
    "source": [
     "# Extracted document figures, bounding boxes, and images\n",
     "figure_data = requests.get(f\"{results_endpoint}/extractions/figures\")\n",
-    "print(json.dumps(figure_data.json(), indent=2))"
+    "print(json.dumps(figure_data.json(), indent=2))\n"
    ]
   },
   {
@@ -178,7 +178,7 @@
    "source": [
     "# Extracted document tables, bounding boxes, and images\n",
     "table_data = requests.get(f\"{results_endpoint}/extractions/tables\")\n",
-    "print(json.dumps(table_data.json(), indent=2))"
+    "print(json.dumps(table_data.json(), indent=2))\n"
    ]
   },
   {
@@ -201,7 +201,7 @@
     "print(f'You can access the downloaded zip file at {FileLink(ZIP_DOWNLOAD_PATH)} .\\nIt contains the following files:')\n",
     "\n",
     "with ZipFile(ZIP_DOWNLOAD_PATH, 'r') as zipfile:\n",
-    "    zipfile.printdir()"
+    "    zipfile.printdir()\n"
    ]
   },
   {
@@ -241,7 +241,7 @@
     "                  f\"Page: {row[page_column]}\\n\"\n",
     "                  f\"Bounding Box: {row[bb_column]}\\n\"\n",
     "                  f\"Score: {row['postprocess_score']}\")\n",
-    "            display(Image(os.path.join(td,img_path)))"
+    "            display(Image(os.path.join(td,img_path)))\n"
    ]
   },
   {
@@ -254,7 +254,7 @@
     "show_extractions(\n",
     "    'paper.pdf'.replace('.pdf','_figures.parquet'), \n",
     "    'obj_bbs',\n",
-    "    'obj_page')"
+    "    'obj_page')\n"
    ]
   },
   {
@@ -267,7 +267,7 @@
     "show_extractions(\n",
     "    SAMPLE_PDF_PATH.replace('.pdf','_equations.parquet'), \n",
     "    'equation_bb',\n",
-    "    'equation_page')"
+    "    'equation_page')\n"
    ]
   },
   {
@@ -280,7 +280,7 @@
     "show_extractions(\n",
     "    SAMPLE_PDF_PATH.replace('.pdf','_tables.parquet'), \n",
     "    'obj_bbs',\n",
-    "    'obj_page')"
+    "    'obj_page')\n"
    ]
   },
   {
@@ -290,7 +290,15 @@
     "# Validate Results\n",
     "\n",
     "COSMOS provides the /healthcheck/evaluate endpoint to evaluate the output of a COSMOS job against an expected set of region bounding boxes. Expected bounding boxes can be generated\n",
-    "by the [COSMOS tagger tool](https://github.com/uw-cosmos/cosmos-visualizer), but should be converted from XML to JSON for use with the health check endpoint."
+    "by the [COSMOS tagger tool](https://github.com/uw-cosmos/cosmos-visualizer), but should be converted from XML to JSON for use with the health check endpoint. The health check endpoint\n",
+    "returns the [mean average precision score](https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Mean_average_precision) for each of the 3 relevant region\n",
+    "identification classes (figures, tables, and equations) according to the following procedure:\n",
+    "\n",
+    "* For each threshold between 50% and 95%, in 5% intervals:\n",
+    "* Label each Cosmos extraction as a true positive if its intersection-over-union with a ground truth region is greater than the threshold\n",
+    "* Compute the [average precision](https://en.wikipedia.org/wiki/Evaluation_measures_(information_retrieval)#Average_precision) of the set of extractions at the given threshold\n",
+    "  * Average Precision is a measure of the change in precision and recall of the model as results with lower confidence scores are considered\n",
+    "* Average the average precision score from each i-o-u threshold"
    ]
   },
   {
@@ -304,7 +312,7 @@
     "\n",
     "    response = requests.post(evaluate_endpoint, json=json.loads(expected_regions.read()))\n",
     "\n",
-    "    print(json.dumps(response.json(),indent=2))"
+    "    print(json.dumps(response.json(),indent=2))\n"
    ]
   }
  ],


### PR DESCRIPTION
Replaces the simple overlapping area percent score with a calculation of Mean Average Precision. The calculation is roughly as follows:
- For each Cosmos region, compute the best intersection-over-union with a ground truth region
- Set an intersection-over-union threshold for determining whether a cosmos region correctly labels a ground truth union. Start at 50%, then go up to 95% in 5% increments
- For each threshold, compute the average precision score of the set of Cosmos regions
  - Average precision is a metric that incorporates both the precision and recall of Cosmos' predictions
  - Precision is the fraction of Cosmos predictions that are correct (correct cosmos predictions / all cosmos predictions)
  - Recall is the fraction of ground truths that are identified by cosmos (correct cosmos predictions / all ground truth values)
  - Average precision represents the the relationship between precision and recall, as larger subsets of the prediction with decreasing confidence are considered
  - This is done by plotting recall on the x axis and precision the y axis, then approximating the area under the curve via Σ precision * Δ recall 
- Sum the average precision score at each intersection-over-union threshold, and for each region classification, to get the mean average precision

A good article on the meaning/computation of average precision can be found here: https://www.v7labs.com/blog/mean-average-precision
