### PR TITLE
Return layout bbox even if no text is found

### DIFF
--- a/cosmos/ingestion/ingest/utils/pdf_extractor.py
+++ b/cosmos/ingestion/ingest/utils/pdf_extractor.py
@@ -71,7 +71,7 @@ def parse_pdf(fp):
                         #        text = ''
                         #        pos = (10000,10000,-1,-1)
     if len(positions) == 0:
-        return None, None                      
+        return None, layout.bbox
     x1, y1, x2, y2 = list(zip(*positions))
     df = pd.DataFrame({
         "text": texts,


### PR DESCRIPTION
https://opensciencegrid.atlassian.net/browse/XDD-210

# Previous behavior:
For PDFs without LTTextbox regions in the PDFMiner extraction process,`limit` was set to None, resulting in an abort [here](https://github.com/UW-COSMOS/Cosmos/blob/master/htcosmos/make_parquet.py#L275)

# New behavior:
Processing continues and extractions are created. To my delight (and surprise) the downstream processing gracefully handles the lack of metadata dataframe.