### PR TITLE
XDD 264/cpu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,5 +22,5 @@ esac
 
 
 echo "Creating image $IMAGE tagged with $VERSION"
-docker buildx build --load --platform linux/arm64  --build-arg="VERSION=$VERSION" --build-arg="GIT_HASH=$GIT_HASH" -t uwcosmos/$IMAGE:$VERSION -f deployment/$DOCKERFILE.Dockerfile .
-#docker buildx build --push --platform linux/amd64,linux/arm64  --build-arg="VERSION=$VERSION" --build-arg="GIT_HASH=$GIT_HASH" -t uwcosmos/$IMAGE:$VERSION -f deployment/$DOCKERFILE.Dockerfile .
+#docker buildx build --push --platform linux/arm64  --build-arg="VERSION=$VERSION" --build-arg="GIT_HASH=$GIT_HASH" -t uwcosmos/$IMAGE:$VERSION -f deployment/$DOCKERFILE.Dockerfile .
+docker buildx build --push --platform linux/amd64,linux/arm64  --build-arg="VERSION=$VERSION" --build-arg="GIT_HASH=$GIT_HASH" -t uwcosmos/$IMAGE:$VERSION -f deployment/$DOCKERFILE.Dockerfile .

--- a/cosmos_service/src/process.py
+++ b/cosmos_service/src/process.py
@@ -17,7 +17,8 @@ from work_queue import OOM_ERROR_EXIT_CODE
 import shutil
 import argparse
 
-os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+if torch.cuda.is_available():
+    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 #os.environ['MODEL_CONFIG']="/configs/lp_genseg_improvement_config.yaml"
 os.environ['MODEL_CONFIG']="/configs/model_config.yaml"
 #os.environ["WEIGHTS_PTH"]="/weights/lp_genseg_improvement_model_final.pth"


### PR DESCRIPTION
- Only set CUDA_VISIBLE_DEVICES if cuda is available. Setting the env var always was [propagating into make_parquet.py](https://github.com/UW-COSMOS/Cosmos/blob/master/htcosmos/make_parquet.py#L601) and causing issues when trying to load the model downstream.

With ongoing work in XDD-252 (build updates + ARM support), this will close the loop on https://github.com/DARPA-ASKEM/orchestration/issues/391#issuecomment-2075031623
