### PR TITLE
Watermark filtration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,5 +22,6 @@ esac
 
 
 echo "Creating image $IMAGE tagged with $VERSION"
-#docker buildx build --push --platform linux/arm64  --build-arg="VERSION=$VERSION" --build-arg="GIT_HASH=$GIT_HASH" -t uwcosmos/$IMAGE:$VERSION -f deployment/$DOCKERFILE.Dockerfile .
+#docker build --network=host --build-arg="VERSION=$VERSION" --build-arg="GIT_HASH=$GIT_HASH" -t uwcosmos/$IMAGE:$VERSION -f deployment/$DOCKERFILE.Dockerfile .
+#docker buildx build --load --platform linux/arm64  --build-arg="VERSION=$VERSION" --build-arg="GIT_HASH=$GIT_HASH" -t uwcosmos/$IMAGE:$VERSION -f deployment/$DOCKERFILE.Dockerfile .
 docker buildx build --push --platform linux/amd64,linux/arm64  --build-arg="VERSION=$VERSION" --build-arg="GIT_HASH=$GIT_HASH" -t uwcosmos/$IMAGE:$VERSION -f deployment/$DOCKERFILE.Dockerfile .

--- a/cosmos_service/src/process.py
+++ b/cosmos_service/src/process.py
@@ -39,7 +39,7 @@ OOM_ERROR_MESSAGES = [
 def _get_parquet_files_to_convert(cosmos_out_dir, pdf_name):
     return [f'{cosmos_out_dir}/{pdf_name}{suffix}.parquet' for suffix in PARQUET_SUFFIXES]
 
-def process_document(pdf_dir: str, job_id: str, compress_images: bool = True, extract_tables: bool = False):
+def process_document(pdf_dir: str, job_id: str, compress_images: bool = True, extract_tables: bool = False, filter_watermarks = False):
     """
     Run a single document through the COSMOS pipeline.
     TODO: This adds the significant overhead of loading the model into memory with each run
@@ -55,7 +55,7 @@ def process_document(pdf_dir: str, job_id: str, compress_images: bool = True, ex
 
         cosmos_error : Exception = None
         try:
-            mp.main_process(pdf_dir, page_info_dir, cosmos_out_dir)
+            mp.main_process(pdf_dir, page_info_dir, cosmos_out_dir, filter_watermarks)
             if compress_images:
                 mp.resize_files(cosmos_out_dir)
             if extract_tables:
@@ -86,5 +86,6 @@ if __name__ == '__main__':
     parser.add_argument("job_id")
     parser.add_argument("compress_images", type=lambda v: v.lower() == 'true', default=True)
     parser.add_argument("extract_tables", type=lambda v: v.lower() == 'true', default=False)
+    parser.add_argument("filter_watermarks", type=lambda v: v.lower() == 'true', default=False)
     args = parser.parse_args()
-    process_document(args.pdf_dir, args.job_id, args.compress_images, args.extract_tables)
+    process_document(args.pdf_dir, args.job_id, args.compress_images, args.extract_tables, args.filter_watermarks)

--- a/cosmos_service/src/routers/process.py
+++ b/cosmos_service/src/routers/process.py
@@ -42,6 +42,7 @@ async def process_document(
     pdf: UploadFile = File(..., description="The document to process with COSMOS", media_type="application/pdf"),
     compress_images: bool = Form(True, description="Whether to generate compressed or full-resolution images of extractions"),
     extract_tables: bool = Form(False, description="Whether to attempt to extract detected tables as dataframes"),
+    filter_watermarks: bool = Form(False, description="Whether to attempt to detect and filter watermarks"),
     use_cache: bool = Form(True, description="Whether to reuse cached results for the given PDF, if present")
     ) -> JobCreationResponse:
     """
@@ -65,7 +66,7 @@ async def process_document(
         session.add(CosmosSessionJob(job_id, pdf.filename.replace('.pdf', ''), pdf_hash, pdf_len, job_output_dir))
         session.commit()
 
-    await queue.put((job_output_dir, job_id, compress_images, extract_tables))
+    await queue.put((job_output_dir, job_id, compress_images, extract_tables, filter_watermarks))
 
     return _build_process_response("PDF Processing in Background", job_id, request.url)
 

--- a/cosmos_service/src/util/text_layer_utils.py
+++ b/cosmos_service/src/util/text_layer_utils.py
@@ -1,4 +1,4 @@
-from fitz.__main__ import gettext
+from pymupdf.__main__ import gettext
 from tempfile import NamedTemporaryFile
 from typing import List
 import re
@@ -29,7 +29,7 @@ r"""(
 )""", re.VERBOSE)
 
 class PyMuPDFGetTextWrapper:
-    """ Duck-type copy of the argparser used for pymupdf's command line arguments to gettext 
+    """ Duck-type copy of the argparser used for pymupdf's command line arguments to gettext
     TODO this is very fragile since the API for gettext might change
     """
     mode: str

--- a/cosmos_service/src/work_queue.py
+++ b/cosmos_service/src/work_queue.py
@@ -19,8 +19,8 @@ async def _cosmos_worker(work_queue: asyncio.Queue):
     blocking issues in Python's async framework
     """
     while True:
-        (job_output_dir, job_id, compress_images, extract_tables) = await work_queue.get()
-        proc = await asyncio.create_subprocess_exec(sys.executable, COSMOS_SCRIPT, job_output_dir, job_id, str(compress_images), str(extract_tables))
+        (job_output_dir, job_id, compress_images, extract_tables, filter_watermarks) = await work_queue.get()
+        proc = await asyncio.create_subprocess_exec(sys.executable, COSMOS_SCRIPT, job_output_dir, job_id, str(compress_images), str(extract_tables), str(filter_watermarks))
         result = await proc.wait()
         queue.task_done()
 

--- a/htcosmos/make_parquet.py
+++ b/htcosmos/make_parquet.py
@@ -527,7 +527,7 @@ def aggregate_pages(filename, pages, page_info_dir, out_dir, postprocess_model, 
         result_df['detect_score'] = result_df['scores'].apply(lambda x: x[0])
         result_df.to_parquet(os.path.join(out_dir, f'{dataset_id}.parquet'), engine='pyarrow', compression='gzip')
         for aggregation in aggregations:
-            aggregate_df = aggregate_router(result_df, aggregate_type=aggregation, write_images_pth=out_dir, source_pdf=filename, pdf_dir=pdf_dir)
+            aggregate_df = aggregate_router(result_df, aggregate_type=aggregation, write_images_pth=out_dir, source_pdf=filename, pdf_directory=pdf_dir)
             name = f'{dataset_id}_{aggregation}.parquet'
             aggregate_df.to_parquet(os.path.join(out_dir, name), engine='pyarrow', compression='gzip')
 

--- a/htcosmos/make_parquet.py
+++ b/htcosmos/make_parquet.py
@@ -168,7 +168,7 @@ def pull_meta(meta, limit, page_num, scale_w, scale_h):
     The model, model_config and device_str values can be None if processing is just doing the propose step
 
 """
-def process_pages(filename, pages, page_info_dir, meta, limit, model, model_config, device_str):
+def process_pages(filename, pages, page_info_dir, meta, limit, model, model_config, device_str, filter_watermarks):
 
     just_propose = os.environ.get("JUST_PROPOSE") is not None
 
@@ -288,7 +288,8 @@ def process_pages(filename, pages, page_info_dir, meta, limit, model, model_conf
         # get proposed coords for use by the inference model
         if make_proposals:
             tlog(f'{page_name} get proposals')
-            proposals = get_proposals(img)
+            proposals = get_proposals(img, filter_watermarks=filter_watermarks)
+            write_regions(image_path, proposals)
             mfd_lp_proposals = get_mfd_lp_proposals(img, 0.85)
             obj['proposals'] = proposals
             if just_propose:
@@ -495,6 +496,7 @@ def aggregate_page(image_path, detected_key, postprocess_model, pp_classes):
 def aggregate_pages(filename, pages, page_info_dir, out_dir, postprocess_model, pp_classes, aggregations):
 
     pdf_name = os.path.basename(filename)
+    pdf_dir = os.path.dirname(filename)
     dataset_id = Path(filename).stem
     results = [] # result list, saved as parquet
     objs = []    # intermediate page dicts
@@ -525,7 +527,7 @@ def aggregate_pages(filename, pages, page_info_dir, out_dir, postprocess_model, 
         result_df['detect_score'] = result_df['scores'].apply(lambda x: x[0])
         result_df.to_parquet(os.path.join(out_dir, f'{dataset_id}.parquet'), engine='pyarrow', compression='gzip')
         for aggregation in aggregations:
-            aggregate_df = aggregate_router(result_df, aggregate_type=aggregation, write_images_pth=out_dir, source_pdf=filename)
+            aggregate_df = aggregate_router(result_df, aggregate_type=aggregation, write_images_pth=out_dir, source_pdf=filename, pdf_dir=pdf_dir)
             name = f'{dataset_id}_{aggregation}.parquet'
             aggregate_df.to_parquet(os.path.join(out_dir, name), engine='pyarrow', compression='gzip')
 
@@ -549,7 +551,7 @@ def aggregate_pages(filename, pages, page_info_dir, out_dir, postprocess_model, 
         stats         - dict of counts of processing successes and failures
 
 """
-def main_process(pdf_dir, page_info_dir, out_dir):
+def main_process(pdf_dir, page_info_dir, out_dir, filter_watermarks=False):
     resume_mode = False # True if may be resuming from an previous run
     # counts of stuff we do or failed to do
     stats = {'gs':0, 'gs_error':0,
@@ -742,7 +744,7 @@ def main_process(pdf_dir, page_info_dir, out_dir):
 
                 success, objs, infofiles = process_pages(filename, pages, page_info_dir,
                                                             meta, limit,
-                                                            model, model_config, device_str)
+                                                            model, model_config, device_str, filter_watermarks)
                 if success:
                     num = len(objs)
                     if just_propose:


### PR DESCRIPTION
Quick and dirty attempt to mask watermarks that are causing issues in the proposal generation. These changes:
- Add a region mask to get_proposals
- Will detect tall and skinny regions of text and mask them
- add `filter_watermarks` parameter to the data form of the COSMOS service API 